### PR TITLE
Migration from Dockerfile-based builds to bazel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
+.DS_Store
+.idea/
+
 .terraform*
 terraform.tfstate*
+**tfplan**
 terraform.tfvars
 pyrios/main
 pyrios/pyrios
@@ -7,3 +11,7 @@ pyrios/vet.report
 pyrios-ui/main
 test/__pycache__
 k8s.env
+
+
+# bazel
+bazel-**

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,23 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.10.1 AS build
-WORKDIR /go/src/app
-COPY main.go .
-RUN go get -d && CGO_ENABLE=0 GOOS=linux GOARCH=amd64 go build -o pyrios-ui -v .
+# gazelle:proto package
+# gazelle:proto_group go_package
 
-FROM debian:stretch-slim
-# hadolint ignore=DL3008
-RUN \
-    apt-get update \
-    && apt-get install --no-install-recommends -y ca-certificates \
-    && useradd -ms /bin/bash -U app \
-    && apt-get -y autoremove \
-    && apt-get clean \
-    && rm -rf /var/lib/apt/lists/*
-USER app
-WORKDIR /home/app
-COPY --chown=app --from=build /go/src/app/pyrios-ui .
-COPY static ./static/
-EXPOSE  8080
-ENTRYPOINT ["/home/app/pyrios-ui"]
+load("@bazel_gazelle//:def.bzl", "gazelle")
+
+gazelle(
+    name = "gazelle",
+    prefix = "github.com/GoogleCloudPlatform/gke-enterprise-demo",
+)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,148 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Standard bazel golang support
+http_archive(
+    name = "io_bazel_rules_go",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.15.3/rules_go-0.15.3.tar.gz",
+    sha256 = "97cf62bdef33519412167fd1e4b0810a318a7c234f5f8dc4f53e2da86241c492",
+)
+load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+go_rules_dependencies()
+go_register_toolchains()
+
+# gazelle rules
+http_archive(
+    name = "bazel_gazelle",
+    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.14.0/bazel-gazelle-0.14.0.tar.gz",
+    sha256 = "c0a5739d12c6d05b6c1ad56f2200cb0b57c5a70e03ebd2f7b87ce88cabf09c7b",
+)
+
+load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")
+
+gazelle_dependencies()
+
+
+# bazel rules for docker
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "io_bazel_rules_docker",
+    sha256 = "29d109605e0d6f9c892584f07275b8c9260803bf0c6fcb7de2623b2bedc910bd",
+    strip_prefix = "rules_docker-0.5.1",
+    urls = ["https://github.com/bazelbuild/rules_docker/archive/v0.5.1.tar.gz"],
+)
+
+load(
+    "@io_bazel_rules_docker//container:container.bzl",
+    "container_pull",
+    container_repositories = "repositories",
+)
+
+container_repositories()
+
+# bazel go image rules
+load(
+    "@io_bazel_rules_docker//go:image.bzl",
+    _go_image_repos = "repositories",
+)
+
+_go_image_repos()
+
+
+# external dependencies
+go_repository(
+    name = "com_google_cloud_go",
+    importpath = "cloud.google.com/go",
+    tag = "v0.25.0",
+)
+
+go_repository(
+    name = "io_opencensus_go",
+    importpath = "go.opencensus.io",
+    tag = "v0.17.0",
+)
+
+go_repository(
+    name = "com_github_tidwall_gjson",
+    importpath = "github.com/tidwall/gjson",
+    tag = "v1.1.3",
+)
+
+go_repository(
+    name = "io_opencensus_go_contrib_exporter_stackdriver",
+    importpath = "contrib.go.opencensus.io/exporter/stackdriver",
+    tag = "v0.6.0",
+)
+
+go_repository(
+    name = "org_golang_google_api",
+    importpath = "google.golang.org/api",
+    commit = "e5ba110cb6cd042d05ea6ea2ce9dd13198c6387a",
+)
+
+go_repository(
+    name = "org_golang_x_oauth2",
+    importpath = "golang.org/x/oauth2",
+    commit = "d2e6202438beef2727060aa7cabdd924d92ebfd9",
+)
+
+go_repository(
+    name = "com_github_tidwall_match",
+    importpath = "github.com/tidwall/match",
+    commit = "1731857f09b1f38450e2c12409748407822dc6be",
+)
+
+go_repository(
+    name = "com_github_googleapis_gax_go",
+    importpath = "github.com/googleapis/gax-go",
+    commit = "1ef592c90f479e3ab30c6c2312e20e13881b7ea6",
+)
+
+go_repository(
+    name = "com_github_aws_aws_sdk_go",
+    importpath = "github.com/aws/aws-sdk-go",
+    tag = "v1.15.42",
+)
+
+go_repository(
+    name = "org_golang_x_sync",
+    importpath = "golang.org/x/sync",
+    commit = "1d60e4601c6fd243af51cc01ddf169918a5407ca",
+)
+
+go_repository(
+    name = "go_googleapis",
+    importpath = "google.golang.org/api",
+    commit = "e5ba110cb6cd042d05ea6ea2ce9dd13198c6387a",
+)
+
+go_repository(
+    name = "org_golang_google_grpc",
+    importpath = "google.golang.org/grpc",
+    tag = "v1.15.0",
+)
+
+go_repository(
+    name = "org_golang_google_grpc",
+    importpath = "google.golang.org/grpc",
+    tag = "v1.15.0",
+)
+
+go_repository(
+    name = "com_github_golang_protobuf",
+    importpath = "github.com/golang/protobuf",
+    tag = "v1.0.0",
+)

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -1,0 +1,22 @@
+package(default_visibility = ["//visibility:public"])
+
+sh_test(
+    name = "verify-boilerplate",
+    srcs = ["verify-boilerplate.sh"],
+    tags = ["manual"],
+)
+
+sh_test(
+    name = "verify-gofmt",
+    srcs = ["verify-gofmt.sh"],
+    tags = ["manual"],
+)
+
+test_suite(
+    name = "verify-all",
+    tags = ["manual"],
+    tests = [
+        "verify-boilerplate",
+        "verify-gofmt",
+    ],
+)

--- a/hack/common.sh
+++ b/hack/common.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# common.sh has helper functions, and is sourced by the other scripts in this directory
+set -o errexit
+set -o nounset
+set -o pipefail
+
+PROJECT_ROOT=$(dirname "${BASH_SOURCE}")/..

--- a/hack/verify-boilerplate.sh
+++ b/hack/verify-boilerplate.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright 2014 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. $(dirname "${BASH_SOURCE}")/common.sh
+
+boiler="${REPO_ROOT}/hack/boilerplate/boilerplate.py $@"
+
+files_need_boilerplate=( `${boiler}` )
+
+if [[ -z ${files_need_boilerplate+x} ]]; then
+    exit
+fi
+
+TO_REMOVE=(${PWD}/federation/model/bindata.go ${PWD}/upup/models/bindata.go)
+TEMP_ARRAY=()
+
+for pkg in "${files_need_boilerplate[@]}"; do
+    for remove in "${TO_REMOVE[@]}"; do
+        KEEP=true
+        if [[ ${pkg} == ${remove} ]]; then
+            KEEP=false
+            break
+        fi
+    done
+    if ${KEEP}; then
+        TEMP_ARRAY+=(${pkg})
+    fi
+done
+
+if [[ ${#TEMP_ARRAY[@]} -gt 0 ]]; then
+  for file in "${TEMP_ARRAY[@]}"; do
+    echo "FAIL: Boilerplate header is wrong for: ${file}"
+  done
+  echo "FAIL: Please execute ./hack/update-header.sh"
+  exit 1
+fi

--- a/hack/verify-gofmt.sh
+++ b/hack/verify-gofmt.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Kubernetes Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+. $(dirname "${BASH_SOURCE}")/common.sh
+
+GOFMT="gofmt -s -w"
+
+bad_files=$(git ls-files "*.go" | grep -v vendor | xargs -I {} $GOFMT -l {})
+if [[ -n "${bad_files}" ]]; then
+  echo "FAIL: '$GOFMT' needs to be run on the following files: "
+  echo "${bad_files}"
+  echo "FAIL: please execute make gofmt"
+  exit 1
+fi

--- a/pyrios-ui/BUILD.bazel
+++ b/pyrios-ui/BUILD.bazel
@@ -1,0 +1,68 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_push", "container_image")
+
+go_binary(
+    name = "pyrios-ui",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/GoogleCloudPlatform/gke-enterprise-demo/pyrios-ui",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_github_tidwall_gjson//:go_default_library",
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+        "@com_google_cloud_go//monitoring/apiv3:go_default_library",
+        "@go_googleapis//google/api:metric_go_proto",
+        "@go_googleapis//google/api:monitoredres_go_proto",
+        "@go_googleapis//google/monitoring/v3:monitoring_go_proto",
+        "@io_bazel_rules_go//proto/wkt:timestamp_go_proto",
+        "@io_opencensus_go//trace:go_default_library",
+        "@io_opencensus_go_contrib_exporter_stackdriver//:go_default_library",
+    ],
+)
+
+go_image(
+    name = "go_image_base",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+)
+
+container_image(
+    name = "go_image",
+    base = ":go_image_base",
+    ports = ["9200"],
+    files = ["static"],
+    directory = "/app",
+    workdir = "/app",
+    stamp = True,
+)
+
+container_push(
+    name = "push",
+    format = "Docker",
+    image = ":go_image",
+    registry = "$(REGISTRY)",
+    repository = "$(REPOSITORY)",
+    tag = "$(TAG)",
+)

--- a/pyrios-ui/main.go
+++ b/pyrios-ui/main.go
@@ -30,9 +30,9 @@ import (
 
 	"cloud.google.com/go/compute/metadata"
 	monitoring "cloud.google.com/go/monitoring/apiv3"
+	"contrib.go.opencensus.io/exporter/stackdriver"
 	googlepb "github.com/golang/protobuf/ptypes/timestamp"
 	"github.com/tidwall/gjson"
-	"contrib.go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/trace"
 	metricpb "google.golang.org/genproto/googleapis/api/metric"
 	monitoredrespb "google.golang.org/genproto/googleapis/api/monitoredres"

--- a/pyrios-ui/manifests/deployment.yaml
+++ b/pyrios-ui/manifests/deployment.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: pyrios-ui
-        image: gcr.io/pso-examples/pyrios-ui:1.0.1
+        image: gcr.io/pso-examples/pyrios-ui:latest
         imagePullPolicy: Always
         ports:
         - containerPort: 8080

--- a/pyrios/BUILD.bazel
+++ b/pyrios/BUILD.bazel
@@ -1,0 +1,60 @@
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@io_bazel_rules_docker//container:container.bzl", "container_push", "container_image")
+
+go_binary(
+    name = "pyrios",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/GoogleCloudPlatform/gke-enterprise-demo/pyrios",
+    visibility = ["//visibility:private"],
+    deps = [
+        "@com_google_cloud_go//compute/metadata:go_default_library",
+        "@io_opencensus_go//trace:go_default_library",
+        "@io_opencensus_go_contrib_exporter_stackdriver//:go_default_library",
+    ],
+)
+
+go_image(
+    name = "go_image_base",
+    embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    pure = "on",
+)
+
+container_image(
+    name = "go_image",
+    base = ":go_image_base",
+    ports = ["9200"],
+    workdir = "/app",
+    stamp = True,
+)
+
+container_push(
+    name = "push",
+    format = "Docker",
+    image = ":go_image",
+    registry = "$(REGISTRY)",
+    repository = "$(REPOSITORY)",
+    tag = "$(TAG)",
+)

--- a/pyrios/main.go
+++ b/pyrios/main.go
@@ -25,8 +25,8 @@ package main
 import (
 	"cloud.google.com/go/compute/metadata"
 	"context"
+	"contrib.go.opencensus.io/exporter/stackdriver"
 	"fmt"
-	"go.opencensus.io/exporter/stackdriver"
 	"go.opencensus.io/trace"
 	"io"
 	"log"

--- a/pyrios/manifests/deployment.yaml
+++ b/pyrios/manifests/deployment.yaml
@@ -32,7 +32,7 @@ spec:
     spec:
       containers:
       - name: pyrios
-        image: gcr.io/pso-examples/pyrios:1.0.0
+        image: gcr.io/pso-examples/pyrios:latest
         env:
         - name: ES_SERVER
           valueFrom:


### PR DESCRIPTION
Migrating from dockerfile based builds to bazel. This is WIP. Will tag when we're ready to review and I'll try to limit the scope/size of this to make it reasonable to review.

Changelog:
* revised .gitignore for bazel workflow
* updated stackdriver exporter imports because the library moved into contrib
* building binaries in bazel
* building images in bazel

To come for this PR:
- [x] verify that these images work by swapping these out with the existing 
- [x] update Makefile for this bazel workflow

There is a bunch of follow-on work to come but given the size of this PR, I'd like to review and get this one done first as it can merge without them.