### PR TITLE
Fix upgrade script with the official elasticsearch docker images

### DIFF
--- a/README.md
+++ b/README.md
@@ -476,8 +476,8 @@ service "elasticsearch-discovery" deleted
 * [Get higher availability with Regional Persistent Disks on Google
   Kubernetes
   Engine](https://cloudplatform.googleblog.com/2018/05/Get-higher-availability-with-Regional-Persistent-Disks-on-Google-Kubernetes-Engine.html?m=1)
-* [pires Elasticsearch
-  project](https://github.com/pires/kubernetes-elasticsearch-cluster)
+* [Elasticsearch
+  docker images repo](https://github.com/elastic/elasticsearch-docker)
 * [ElasticSearch Cluster Sample
   data](https://www.elastic.co/guide/en/kibana/current/tutorial-load-dataset.html)
 * [ElasticSearch bulk load

--- a/elasticsearch/Elasticsearch-Upgrade.md
+++ b/elasticsearch/Elasticsearch-Upgrade.md
@@ -71,7 +71,7 @@ on a Mac workstation.
 
 This example was tested using Elasticsearch version `6.2.4` and upgrading to
 version `6.3.1`.  If you wish to use different versions, make sure the desired
-versions are available in the [Pires docker images](https://quay.io/repository/pires/docker-elasticsearch-kubernetes?tab=tags) listing.
+versions are available in the [Elasticsearch docker images](https://www.docker.elastic.co/#elasticsearch) listing.
 
 The manifests used to build and upgrade the Elasticsearch cluster are based on
 the [Pires docker-elasticsearch-kubernetes repo](https://github.com/pires/docker-elasticsearch-kubernetes) with several improvements
@@ -166,5 +166,5 @@ watch curl 'http://localhost:9200/_cat/nodes'
 * [Elasticsearch Shard Allocations](https://www.elastic.co/guide/en/elasticsearch/reference/master/shards-allocation.html)
 * [Elasticsearch Rolling Upgrades](https://www.elastic.co/guide/en/elasticsearch/reference/current/rolling-upgrades.html)
 * [Pires docker-elasticsearch-kubernetes repo](https://github.com/pires/docker-elasticsearch-kubernetes)
-* [Pires docker images](https://quay.io/repository/pires/docker-elasticsearch-kubernetes?tab=tags)
+* [Elasticsearch docker images](https://www.docker.elastic.co/#elasticsearch)
 * [StatefulSet Canary Rollout](https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#rolling-out-a-canary)

--- a/scripts/upgrade-elasticsearch.sh
+++ b/scripts/upgrade-elasticsearch.sh
@@ -36,7 +36,7 @@ USAGE: $(basename "$0") <new-elasticsearch-version>
 
 Where <new-elasticsearch-version> is a tag available in this
 Docker repository:
-https://quay.io/repository/pires/docker-elasticsearch-kubernetes?tab=tags
+https://www.docker.elastic.co/#elasticsearch
 EOM
   exit 1
 }
@@ -99,7 +99,7 @@ update_deployment() {
   # kubectl patch can be used to update resource objects
   # https://kubernetes.io/docs/tasks/run-application/update-api-object-kubectl-patch/
   kubectl --namespace default patch deployment "${NAME}" \
-    -p '{"spec":{"template":{"spec":{"containers":[{"name":"'"${NAME}"'","image":"quay.io/pires/docker-elasticsearch-kubernetes:'"${VERSION}"'"}]}}}}'
+    -p '{"spec":{"template":{"spec":{"containers":[{"name":"'"${NAME}"'","image":"docker.elastic.co/elasticsearch/elasticsearch:'"${VERSION}"'"}]}}}}'
   # Monitor the upgrade as it progresses
   kubectl rollout status deployment "${NAME}"
 }
@@ -182,7 +182,7 @@ update_statefulset() {
 
   echo "Updating the ${NAME} Statefulset to Elasticsearch version ${VERSION}..."
   kubectl --namespace default patch statefulset "${NAME}" -p \
-    '{"spec":{"template":{"spec":{"containers":[{"name":"'"${NAME}"'","image":"quay.io/pires/docker-elasticsearch-kubernetes:'"${VERSION}"'"}]}}}}' || true
+    '{"spec":{"template":{"spec":{"containers":[{"name":"'"${NAME}"'","image":"docker.elastic.co/elasticsearch/elasticsearch:'"${VERSION}"'"}]}}}}' || true
 
   # For a statefulset with 3 replicas, this will loop three times wth the
   # 'ORDINAL' values 2, 1, and 0


### PR DESCRIPTION
The k8s statefulsets/deployments were changed to work with the official docker images  in #36 . The upgrade script should also use the same images.

Thanks!