### PR TITLE
Upgrade Bazel to 0.23.2

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,7 +25,6 @@ def label = "k8s-infra"
 def containerName = "k8s-node"
 def GOOGLE_APPLICATION_CREDENTIALS    = '/home/jenkins/dev/jenkins-deploy-dev-infra.json'
 
-// temporarily lock the jenkins-k8s-node version to 1.4.5 until successfully upgrade bazel to 0.20.0+
 podTemplate(label: label, yaml: """
 apiVersion: v1
 kind: Pod

--- a/Makefile
+++ b/Makefile
@@ -102,11 +102,15 @@ bootstrap:
 	  bigquery-json.googleapis.com
 
 # 2: Terraform is used to manage the larger infrastructure components
-.PHONY: terraform
-terraform:
+
+.PHONY: terraform_preapply
+terraform_preapply:
 	terraform init terraform/
 	terraform validate -check-variables=false terraform/
 	terraform plan -var "project=$(PROJECT)" -out=tfplan terraform/
+
+.PHONY: terraform
+terraform: terraform_preapply
 	terraform apply tfplan
 
 # 3. We will not be checking secrets into version control. This helps manage that process

--- a/README.md
+++ b/README.md
@@ -214,7 +214,7 @@ jq is used for parsing JSON output from resources within this demo.  Its [instal
 
 #### Install Bazel
 
-Bazel is the build tool used to build the pyrios images used in the demo. Its [installation instructions](https://docs.bazel.build/versions/master/install.html) are available online. At time of writing, the Bazel version tested is 0.21.0.
+Bazel is the build tool used to build the pyrios images used in the demo. Its [installation instructions](https://docs.bazel.build/versions/master/install.html) are available online. At time of writing, the Bazel version tested is 0.23.2.
 
 ### Configure gcloud
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -28,9 +28,10 @@ load(
 
 docker_repositories()
 
+## 54e9742bd2b75facdcf30fe3a1307ca0fad17385 is master@latest
 git_repository(
     name = "io_bazel_rules_k8s",
-    commit = "62ae7911ef60f91ed32fdd48a6b837287a626a80",
+    commit = "54e9742bd2b75facdcf30fe3a1307ca0fad17385",
     remote = "https://github.com/bazelbuild/rules_k8s.git",
 )
 
@@ -59,21 +60,31 @@ k8s_defaults(
     "configmap",
 ]]
 
+# Override protbuf version to bypass compilation error
+# cf. https://github.com/bazelbuild/rules_k8s/issues/240
+http_archive(
+name = "com_google_protobuf",
+strip_prefix = "protobuf-3.6.1.3",
+urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.tar.gz"],
+)
+
 # Standard bazel golang support
 http_archive(
     name = "io_bazel_rules_go",
-    url = "https://github.com/bazelbuild/rules_go/releases/download/0.15.5/rules_go-0.15.5.tar.gz",
-    sha256 = "8f6ec7856863aac58a12c921215c8e9ab1c03cb0c570397fed4a79ade7c0bb4a",
+    url = "https://github.com/bazelbuild/rules_go/releases/download/0.18.1/rules_go-0.18.1.tar.gz",
+    sha256 = "77dfd303492f2634de7a660445ee2d3de2960cbd52f97d8c0dffa9362d3ddef9",
 )
-load("@io_bazel_rules_go//go:def.bzl", "go_rules_dependencies", "go_register_toolchains")
+load("@io_bazel_rules_go//go:deps.bzl", "go_rules_dependencies", "go_register_toolchains")
 go_rules_dependencies()
 go_register_toolchains()
+
+
 
 # gazelle rules
 http_archive(
     name = "bazel_gazelle",
-    url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/0.14.0/bazel-gazelle-0.14.0.tar.gz",
-    sha256 = "c0a5739d12c6d05b6c1ad56f2200cb0b57c5a70e03ebd2f7b87ce88cabf09c7b",
+    sha256 = "3c681998538231a2d24d0c07ed5a7658cb72bfb5fd4bf9911157c0e9ac6a2687",
+    urls = ["https://github.com/bazelbuild/bazel-gazelle/releases/download/0.17.0/bazel-gazelle-0.17.0.tar.gz"],
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies", "go_repository")

--- a/scripts/cloud-create.sh
+++ b/scripts/cloud-create.sh
@@ -53,16 +53,13 @@ kubectl  \
   create configmap esconfig \
   --from-literal=ES_SERVER="$LB_IP" || true
 
-# Note:  the Bazel flag incompatible_package_name_is_a_function, while necessary for a successful build, is only valid in Bazel v0.21.
-# This flag is deprecated in Bazel v0.22+
 bazel run \
-  --incompatible_package_name_is_a_function=false \
   --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
   --define cluster="${CONTEXT}" \
   --define repo="${REPO}" \
   //pyrios-ui:k8s.apply
+
 bazel run \
-  --incompatible_package_name_is_a_function=false \
   --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
   --define cluster="${CONTEXT}" \
   --define repo="${REPO}" \

--- a/scripts/cloud-destroy.sh
+++ b/scripts/cloud-destroy.sh
@@ -37,16 +37,13 @@ if [[ ! $(kubectl config use-context "$CONTEXT") ]]; then
 fi
 
 # delete k8s resources
-# Note:  the Bazel flag incompatible_package_name_is_a_function, while necessary for a successful build, is only valid in Bazel v0.21.
-# This flag is deprecated in Bazel v0.22+
 bazel run \
-  --incompatible_package_name_is_a_function=false \
   --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
   --define cluster="${CONTEXT}" \
   --define repo="${REPO}" \
   //pyrios-ui:k8s.delete
+
 bazel run \
-  --incompatible_package_name_is_a_function=false \j
   --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
   --define cluster="${CONTEXT}" \
   --define repo="${REPO}" \


### PR DESCRIPTION
The major change is `WORKSPACE` where protobuf has to be upgraded to a specific version to resolve the `incompatible_package_name_is_a_function` issue.  This is especially necessary for Bazel v0.22+, where the `incompatible_package_name_is_a_function` flag has been deprecated. 

Upgrading to v0.23.2 for now because it is the version included in Cloudshell. 