### PR TITLE
Use managed node group and add labels 

### DIFF
--- a/scripts/get-gcloud-account.sh
+++ b/scripts/get-gcloud-account.sh
@@ -16,9 +16,10 @@
 
 ## This script is used exclusively by terraform to determine the account currently logged in
 ## This script is called using the external provider from Terraform
+## Because a label can only have 63 bytes, truncate to 63 characters
 
 set -e
-gcloud_account=$(gcloud config get-value core/account | sed -e 's/[^-_[:alnum:]]/_/g')
+gcloud_account=$(gcloud config get-value core/account | sed -e 's/[^-_[:alnum:]]/_/g' | cut -c -63 )
 
 ## Terraform external provider requires that the output of the script to be a valid JSON string
 jq -n --arg name $gcloud_account '{"gcloud_account": $name}'

--- a/scripts/get-gcloud-account.sh
+++ b/scripts/get-gcloud-account.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# Copyright 2018 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## This script is used exclusively by terraform to determine the account currently logged in
+## This script is called using the external provider from Terraform
+
+set -e
+gcloud_account=$(gcloud config get-value core/account | sed -e 's/[^-_[:alnum:]]/_/g')
+
+## Terraform external provider requires that the output of the script to be a valid JSON string
+jq -n --arg name $gcloud_account '{"gcloud_account": $name}'

--- a/scripts/get-gcloud-account.sh
+++ b/scripts/get-gcloud-account.sh
@@ -16,10 +16,10 @@
 
 ## This script is used exclusively by terraform to determine the account currently logged in
 ## This script is called using the external provider from Terraform
-## Because a label can only have 63 bytes, truncate to 63 characters
+## Because a label can only have 63 bytes, truncate accordingly
 
 set -e
-gcloud_account=$(gcloud config get-value core/account | sed -e 's/[^-_[:alnum:]]/_/g' | cut -c -63 )
+gcloud_account=$(gcloud config get-value core/account | sed -e 's/[^-_[:alnum:]]/_/g' | cut -b -63 )
 
 ## Terraform external provider requires that the output of the script to be a valid JSON string
 jq -n --arg name $gcloud_account '{"gcloud_account": $name}'

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -19,3 +19,7 @@ limitations under the License.
 data "google_container_engine_versions" "gke_version" {
   zone = "${var.zone_on_prem}"
 }
+
+data "external" "account" {
+  program = ["sh", "${path.module}/../scripts/get-gcloud-account.sh"]
+}

--- a/terraform/staging.tf
+++ b/terraform/staging.tf
@@ -21,6 +21,11 @@ limitations under the License.
 
 // https://cloud.google.com/vpn/docs/how-to/creating-policy-based-vpns
 // Reserve regional external (static) IP addresses
+
+locals {
+  resource_labels = "${merge(var.labels, map("owner", data.external.account.result.gcloud_account) )}"
+}
+
 resource "google_compute_address" "staging_public_ip_1" {
   name   = "gke-enterprise-demo-cloud-public-ip-1"
   region = "${var.region_cloud}"
@@ -76,21 +81,14 @@ resource "google_container_cluster" "staging_on_prem_cluster" {
 
   min_master_version = "${var.gke_master_version}"
 
+  resource_labels = "${local.resource_labels}"
+
   ip_allocation_policy {
     cluster_secondary_range_name = "${module.staging_on_prem.secondary_range_name}"
   }
 
-  node_config {
-    machine_type = "${lookup(var.on_prem, "machine_type")}"
-
-    // https://cloud.google.com/kubernetes-engine/docs/how-to/access-scopes
-    // Enable private gcr.io read access for the same project
-    oauth_scopes = [
-      "https://www.googleapis.com/auth/devstorage.read_only",
-      "https://www.googleapis.com/auth/logging.write",
-      "https://www.googleapis.com/auth/monitoring",
-    ]
-  }
+  remove_default_node_pool = true
+  initial_node_count       = 1
 
   addons_config {
     network_policy_config {
@@ -109,6 +107,31 @@ resource "google_container_cluster" "staging_on_prem_cluster" {
   }
 }
 
+resource "google_container_node_pool" "staging_on_prem_cluster" {
+  name    = "gke-enterprise-staging-on-prem-node-pool"
+  project = "${var.project}"
+
+  cluster    = "${google_container_cluster.staging_on_prem_cluster.name}"
+  zone       = "${var.zone_on_prem}"
+  node_count = 1
+
+  node_config {
+    machine_type = "${lookup(var.on_prem, "machine_type")}"
+
+    // https://cloud.google.com/kubernetes-engine/docs/how-to/access-scopes
+    // Enable private gcr.io read access for the same project
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+    ]
+  }
+
+  lifecycle {
+    ignore_changes = ["id", "node_config.0.metadata"]
+  }
+}
+
 // Creates a Google Kubernetes Engine (GKE) cluster for the cloud
 // https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "staging_cloud_cluster" {
@@ -120,9 +143,37 @@ resource "google_container_cluster" "staging_cloud_cluster" {
 
   min_master_version = "${var.gke_master_version}"
 
+  resource_labels = "${local.resource_labels}"
+
   ip_allocation_policy {
     cluster_secondary_range_name = "${module.staging_cloud.secondary_range_name}"
   }
+
+  remove_default_node_pool = true
+  initial_node_count       = 1
+
+  addons_config {
+    network_policy_config {
+      disabled = false
+    }
+  }
+
+  network_policy {
+    enabled  = true
+    provider = "CALICO" // CALICO is currently the only supported provider
+  }
+
+  lifecycle {
+    ignore_changes = ["network", "subnetwork", "ip_allocation_policy.0.services_secondary_range_name"]
+  }
+}
+
+resource "google_container_node_pool" "staging_cloud_cluster" {
+  name       = "gke-enterprise-staging-cloud-node-pool"
+  project    = "${var.project}"
+  cluster    = "${google_container_cluster.staging_cloud_cluster.name}"
+  zone       = "${var.zone_cloud}"
+  node_count = 1
 
   node_config {
     machine_type = "${lookup(var.cloud, "machine_type")}"
@@ -140,21 +191,9 @@ resource "google_container_cluster" "staging_cloud_cluster" {
     ]
   }
 
-  addons_config {
-    network_policy_config {
-      disabled = false
-    }
-  }
-
-  network_policy {
-    enabled  = true
-    provider = "CALICO" // CALICO is currently the only supported provider
-  }
-
   lifecycle {
-    ignore_changes = ["network", "subnetwork", "ip_allocation_policy.0.services_secondary_range_name"]
+    ignore_changes = ["id", "node_config.0.metadata"]
   }
-
 }
 
 resource "google_bigquery_dataset" "staging-log-sink-dataset" {

--- a/terraform/staging.tf
+++ b/terraform/staging.tf
@@ -23,7 +23,7 @@ limitations under the License.
 // Reserve regional external (static) IP addresses
 
 locals {
-  resource_labels = "${merge(var.labels, map("owner", data.external.account.result.gcloud_account) )}"
+  resource_labels = "${merge(var.labels, map("owner", data.external.account.result.gcloud_account))}"
 }
 
 resource "google_compute_address" "staging_public_ip_1" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -33,7 +33,7 @@ variable "zone_on_prem" {
 }
 
 variable "zone_on_prem_failover" {
-  type = "list"
+  type    = "list"
   default = ["us-central1-b", "us-central1-c"]
 }
 
@@ -67,4 +67,10 @@ variable "on_prem" {
 
 variable "gke_master_version" {
   default = "latest"
+}
+
+// this map should be set should more labels be required to identify the container clusters and node groups
+variable "labels" {
+  type    = "map"
+  default = {}
 }


### PR DESCRIPTION
### Replace default node group with managed node group 
* managed node group is the recommended practice (based on TF docs)
* previous attempts of lifecycle ignore_changes did not work when nodes are in the default node groups, resulting in unnecessary recreation of clusters and nodes at `terraform apply` even when nothing changes.  This gets resolved once default node groups  are disabled. 

### Add label support
* for larger teams, labels are useful as identifiers to users accountable for the resources and for billing reports  
* a mandatory `owner` label is added to the cluster and node group, the value is set to the current gcloud account name, after replacing  characters not permissible in labels with underscores 
* add support for more labels (as map) should it be required