### PR TITLE
Explicit timeouts on GKE operations

### DIFF
--- a/terraform/staging.tf
+++ b/terraform/staging.tf
@@ -105,6 +105,12 @@ resource "google_container_cluster" "staging_on_prem_cluster" {
   lifecycle {
     ignore_changes = ["network", "subnetwork", "ip_allocation_policy.0.services_secondary_range_name"]
   }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+    delete = "30m"
+  }
 }
 
 resource "google_container_node_pool" "staging_on_prem_cluster" {
@@ -166,6 +172,13 @@ resource "google_container_cluster" "staging_cloud_cluster" {
   lifecycle {
     ignore_changes = ["network", "subnetwork", "ip_allocation_policy.0.services_secondary_range_name"]
   }
+
+  timeouts {
+    create = "30m"
+    update = "40m"
+    delete = "30m"
+  }
+
 }
 
 resource "google_container_node_pool" "staging_cloud_cluster" {


### PR DESCRIPTION
Attempting to avoid the following error when the cluster actually is destroyed shortly after the 10m mark passes by extending to 30m:
```
google_container_cluster.staging_cloud_cluster: Still destroying... (ID: gke-enterprise-staging-cloud-cluster, 9m40s elapsed)[0m[0m
google_container_cluster.staging_cloud_cluster: Still destroying... (ID: gke-enterprise-staging-cloud-cluster, 9m50s elapsed)[0m[0m
google_container_cluster.staging_cloud_cluster: Still destroying... (ID: gke-enterprise-staging-cloud-cluster, 10m0s elapsed)[0m[0m
Error applying plan:

1 error(s) occurred:

* google_container_cluster.staging_cloud_cluster (destroy): 1 error(s) occurred:

* google_container_cluster.staging_cloud_cluster: Error waiting for deleting GKE cluster: timeout while waiting for state to become 'DONE' (last state: 'RUNNING', timeout: 10m0s)
```